### PR TITLE
Enable timeline view resize and imrove ttk

### DIFF
--- a/hindsight_server/views/timeline_view.py
+++ b/hindsight_server/views/timeline_view.py
@@ -5,9 +5,9 @@ import platform
 import matplotlib
 import numpy as np
 import pandas as pd
-import tkinter as tk
 import colorcet as cc
-from tkinter import ttk, messagebox
+from tkinter import Tk, ttk
+from tkinter import StringVar, Canvas, messagebox, Toplevel
 from PIL import Image, ImageTk
 
 import tzlocal
@@ -20,34 +20,90 @@ sys.path.insert(0, "./")
 
 from db import HindsightDB
 
-local_timezone = tzlocal.get_localzone()
-video_timezone = ZoneInfo("UTC")
-
 @dataclass
 class Screenshot:
     image: np.array
     text_df: pd.DataFrame
     timestamp: datetime.timestamp
 
+local_timezone = tzlocal.get_localzone()
+video_timezone = ZoneInfo("UTC")
+timeline_scrollbar_height = 50
+
+def get_images_df(db: HindsightDB, front_camera):
+    """Gets a DataFrame of all images at the time of inititation"""
+    if front_camera is None:
+        images_df = db.get_screenshots()
+    elif front_camera:
+        images_df = db.get_frames(applications=["frontCamera"])
+    else:
+        images_df = db.get_frames(applications=["backCamera"])
+    images_df['datetime_utc'] = pd.to_datetime(images_df['timestamp'] / 1000, unit='s', utc=True)
+    images_df['datetime_local'] = images_df['datetime_utc'].apply(lambda x: x.replace(tzinfo=video_timezone).astimezone(local_timezone))
+    return images_df.sort_values(by='datetime_local', ascending=False)
+
+def get_app_color_map(images_df: pd.DataFrame):
+    # Generate a color map for each app, ensuring colors are distinguishable
+    unique_apps = images_df['application'].unique()
+    num_apps = len(unique_apps)
+    
+    # Choose a colormap with a sufficient number of colors
+    cmap = cc.cm['rainbow']  # 'rainbow', 'colorwheel', etc., could also be good choices
+    
+    # Generate color indices spaced evenly throughout the colormap
+    colors = [cmap(i / (num_apps - 1)) if num_apps > 1 else cmap(0.5) for i in range(num_apps)]
+
+    hex_colors = [matplotlib.colors.to_hex(color) for color in colors]
+    
+    return {app: hex_colors[i] for i, app in enumerate(unique_apps)}
+
+def resize_screenshot(screenshot: Screenshot, max_width: int, max_height: int):
+    print((max_width, max_height))
+    height, width, _ = screenshot.image.shape
+    if width > max_width or height > max_height:
+        scaling_factor = min(float(max_width) / width, float(max_height) / height)
+        (sizex, sizey) = (int(width * scaling_factor), int(height * scaling_factor))
+        # max is a hack to prevent / 0 exceptions on startup
+        sizex = max(1, sizex)
+        sizey = max(1, sizey)
+        print('sizes:',(sizex, sizey))
+        screenshot.image = cv2.resize(screenshot.image, (sizex, sizey), interpolation=cv2.INTER_AREA)
+        if screenshot.text_df is not None:
+            screenshot.text_df.loc[:, 'x'] = screenshot.text_df['x'] * scaling_factor
+            screenshot.text_df.loc[:, 'y'] = screenshot.text_df['y'] * scaling_factor
+            screenshot.text_df.loc[:, 'w'] = screenshot.text_df['w'] * scaling_factor
+            screenshot.text_df.loc[:, 'h'] = screenshot.text_df['h'] * scaling_factor
+    return screenshot
+
 class TimelineViewer:
-    def __init__(self, master: tk.Tk, frame_id = None, max_width=1536, max_height=600, images_df=None, front_camera=None):
-        self.master = master
-        self.db = HindsightDB()
-        self.images_df = self.get_images_df(front_camera) if images_df is None else images_df
+    def __init__(self, root: Tk, database: HindsightDB, front_camera=None):
+        screen_width = root.winfo_screenwidth()
+        screen_height = root.winfo_screenheight()
+        max_width = int(screen_width * 0.75)
+        max_height = int(screen_height * 0.75)
+        root.geometry('%dx%d-100-100' % (max_width, max_height)) # fill 3/4 of screen, position 100 px from top right
+        
+        self.master = ttk.Frame(root, borderwidth=5, relief='ridge', padding='10 10 10 10')
+        self.master.grid(column=0, row=0, sticky='nswe')
+        root.columnconfigure(0, weight=1)
+        root.rowconfigure(0, weight=1)
+        self.master.columnconfigure(0, weight=1)
+
+        self.db = database
+        self.images_df = get_images_df(self.db, front_camera)
         self.num_frames = len(self.images_df)
-        self.max_frames_index = max(self.images_df.index)
-        self.app_color_map = self.get_app_color_map()
+        self.max_frames_index = int(max(self.images_df.index)) # cast to int to ensure we have the right datatype
+        self.app_color_map = get_app_color_map(self.images_df)
         self.max_width = max_width
         self.max_height = max_height
         self.full_screen = False
 
         self.screenshots_on_timeline = 40 
 
-        if frame_id is None:
-            self.scroll_frame_num = 0
-        else:
-            self.scroll_frame_num = self.images_df.index.get_loc(self.images_df[self.images_df['id'] == frame_id].index[0])
-        self.scroll_frame_num_var = tk.StringVar()
+        self.scroll_frame_num = 0 # lower index is most recent, index is 0 - based
+        # self.scroll_frame_num = self.images_df.index.get_loc(self.images_df[self.images_df['id'] == frame_id].index[0]) # does this even work??
+        
+        self.frame_timestamp = StringVar(master=self.master, value='--------------')
 
         # For mouse dragging
         self.dragging = False
@@ -56,90 +112,53 @@ class TimelineViewer:
         self.exit_flag = False
 
         self.setup_gui()
-
-    def get_images_df(self, front_camera):
-        """Gets a DataFrame of all images at the time of inititation"""
-        if front_camera is None:
-            images_df = self.db.get_screenshots()
-        elif front_camera:
-            images_df = self.db.get_frames(applications=["frontCamera"])
-        else:
-            images_df = self.db.get_frames(applications=["backCamera"])
-        images_df['datetime_utc'] = pd.to_datetime(images_df['timestamp'] / 1000, unit='s', utc=True)
-        images_df['datetime_local'] = images_df['datetime_utc'].apply(lambda x: x.replace(tzinfo=video_timezone).astimezone(local_timezone))
-        return images_df.sort_values(by='datetime_local', ascending=False)
-    
-    def get_app_color_map(self):
-        # Generate a color map for each app, ensuring colors are distinguishable
-        unique_apps = self.images_df['application'].unique()
-        num_apps = len(unique_apps)
-        
-        # Choose a colormap with a sufficient number of colors
-        cmap = cc.cm['rainbow']  # 'rainbow', 'colorwheel', etc., could also be good choices
-        
-        # Generate color indices spaced evenly throughout the colormap
-        colors = [cmap(i / (num_apps - 1)) if num_apps > 1 else cmap(0.5) for i in range(num_apps)]
-
-        hex_colors = [matplotlib.colors.to_hex(color) for color in colors]
-        
-        return {app: hex_colors[i] for i, app in enumerate(unique_apps)}
     
     def setup_gui(self):
-        self.master.title("Trackpad-Controlled Video Timeline")
 
-        self.top_frame = ttk.Frame(self.master)
-        self.top_frame.pack(fill=tk.X, padx=5, pady=5)
+        self.top_frame = ttk.Frame(self.master, padding='5 5 5 5', style='Frame1.TFrame')
+        self.top_frame.grid(column=0, row=0, sticky='ew')
+        self.top_frame.columnconfigure(0, weight=1) # expand top row's column to fill container
 
         self.search_button = ttk.Button(self.top_frame, text="Search", command=self.open_search_view)
-        self.search_button.pack(side=tk.RIGHT)
+        self.search_button.grid(column=0, row=0, sticky='e')
         
-        # covers the canvas to allow drag selection
-        self.video_label = ttk.Label(self.master)
-        self.video_label.pack()
+        self.video_label = ttk.Label(self.master, anchor='center', style='1.TLabel')
+        self.video_label.grid(column=0, row=1, sticky='nsew')
+        self.master.rowconfigure(1, weight=1) # expand canvas row to fit space
         self.video_label.bind("<Button-1>", self.start_drag)
         self.video_label.bind("<B1-Motion>", self.on_drag)
         self.video_label.bind("<ButtonRelease-1>", self.end_drag)
 
-        self.time_label = ttk.Label(self.master, textvariable=str(self.scroll_frame_num_var), font=("Arial", 24), anchor="e")
-        self.time_label.pack()
+        self.timeline_canvas = Canvas(self.master, height=timeline_scrollbar_height, background='gray75')
+        self.timeline_canvas.grid(column=0, row=2, sticky='ew')
+
+        self.time_label = ttk.Label(self.master, textvariable=self.frame_timestamp, font=("Arial", 24), anchor="e")
+        self.time_label.grid(column=0, row=3)
+        
         self.bind_scroll_event()
-
-        self.timeline_canvas = tk.Canvas(self.master, height=50)
-        self.timeline_canvas.pack(fill=tk.X, padx=5, pady=5)
-
         self.master.bind('<Configure>', lambda e: self.handle_resize())
+        self.master.bind('<Destroy>', lambda e: self.on_window_close())
         
-        self.master.bind('<Escape>', lambda e: self.switch_fullscreen(False))
-        self.master.bind('f', lambda e: self.switch_fullscreen())
-        self.master.bind('F', lambda e: self.switch_fullscreen())
+        self.master.winfo_toplevel().bind('<Escape>', lambda e: self.master.winfo_toplevel().destroy())
+        self.master.winfo_toplevel().bind('f', lambda e: self.switch_fullscreen())
+        self.master.winfo_toplevel().bind('F', lambda e: self.switch_fullscreen())
 
-        self.master.bind("<Right>", self.click_right)
-        self.master.bind("<Left>", self.click_left)
-        
-        self.displayed_frame_num = -1 # ensure that the next refresh picks up a fresh frame
-        self.update_frame_periodically() # begin update loop
+        self.master.winfo_toplevel().bind("<Right>", self.click_right)
+        self.master.winfo_toplevel().bind("<Left>", self.click_left)
+
+        # draw initial frame
+        self.update_frame()
 
     def handle_resize(self):
-        self.update_timeline(self.scroll_frame_num)
-        self.update_frame_periodically(forced_update=True)
+        self.max_width = self.master.winfo_toplevel().winfo_width()
+        self.max_height = self.master.winfo_toplevel().winfo_height()
+        print('size ', (self.max_width, self.max_height))
+        self.master.winfo_toplevel().update() # evaluate geometry manager for cases such as fullscreen and startup
+        self.update_frame()
 
     def switch_fullscreen(self, back_forth=True):
         self.full_screen = not self.full_screen if back_forth else False
-        self.master.attributes("-fullscreen", 1 if self.full_screen else 0)
-    
-    def resize_screenshot(self, screenshot, max_width, max_height):
-        height, width, _ = screenshot.image.shape
-        if width > max_width or height > max_height:
-            scaling_factor = min(max_width / width, max_height / height)
-            new_size = (int(width * scaling_factor), int(height * scaling_factor))
-            screenshot.image = cv2.resize(screenshot.image, new_size, interpolation=cv2.INTER_AREA)
-            if screenshot.text_df is not None:
-                screenshot.text_df.loc[:, 'x'] = screenshot.text_df['x'] * scaling_factor
-                screenshot.text_df.loc[:, 'y'] = screenshot.text_df['y'] * scaling_factor
-                screenshot.text_df.loc[:, 'w'] = screenshot.text_df['w'] * scaling_factor
-                screenshot.text_df.loc[:, 'h'] = screenshot.text_df['h'] * scaling_factor
-        return screenshot
-
+        self.master.winfo_toplevel().attributes("-fullscreen", 1 if self.full_screen else 0)
 
     def get_screenshot(self, i):
         """Loads and resizes the screenshot."""
@@ -148,106 +167,98 @@ class TimelineViewer:
         text_df = self.db.get_ocr_results(frame_id=im_row['id'])
         if set(text_df['text']) == {None}:
             text_df = None
-        screenshot = Screenshot(image=image, text_df=text_df, timestamp=im_row['datetime_local'])
-        screenshot_resized = self.resize_screenshot(screenshot, self.max_width, self.max_height)
-        return screenshot_resized
+        return Screenshot(image=image, text_df=text_df, timestamp=im_row['datetime_local'])
 
-    def update_frame_periodically(self, forced_update=False):
-        # Check if the current scroll position has a preloaded frame
-        if self.scroll_frame_num != self.displayed_frame_num:
-            screenshot = self.get_screenshot(self.scroll_frame_num)
-            self.display_frame(screenshot, self.scroll_frame_num)
-
-        # Schedule the next update
-        if not self.exit_flag and not forced_update:
-            self.master.after(10, self.update_frame_periodically)
-
-    def get_apps_near(self, current_frame_num):
+    def get_apps_near(self, current_frame_num: int):
         timeline_border = self.screenshots_on_timeline // 2
         apps_before = self.images_df.iloc[current_frame_num+1:current_frame_num+timeline_border+1]['application']
         apps_after = self.images_df.iloc[max(current_frame_num-timeline_border, 0):current_frame_num]['application']
         return apps_before, apps_after
 
-    def update_timeline(self, current_frame_num):
+    def update_timeline(self):
         self.timeline_canvas.delete("all")  # Clear existing drawings
         width = self.timeline_canvas.winfo_width()
-        apps_before, apps_after = self.get_apps_near(current_frame_num)  # Implement this function
+        apps_before, apps_after = self.get_apps_near(self.scroll_frame_num)  # Implement this function
 
         timeline_screenshot_width = width / self.screenshots_on_timeline
 
         start_pos = width / 2 # start in the middle of the timeline
         for app in apps_before: # Reverse order of list to start at current screenshot
             color = self.app_color_map[app]
-            self.timeline_canvas.create_rectangle(start_pos, 0, start_pos-timeline_screenshot_width, 50, fill=color, outline='')
+            self.timeline_canvas.create_rectangle(start_pos, 0, start_pos-timeline_screenshot_width, timeline_scrollbar_height, fill=color, outline='')
             start_pos -= timeline_screenshot_width
 
         start_pos = (width / 2)  + timeline_screenshot_width # start in the middle of the timeline
         for app in apps_after[::-1]: # Reverse order of list to start at current screenshot
             color = self.app_color_map[app]
-            self.timeline_canvas.create_rectangle(start_pos, 0, start_pos+timeline_screenshot_width, 50, fill=color, outline='')
+            self.timeline_canvas.create_rectangle(start_pos, 0, start_pos+timeline_screenshot_width, timeline_scrollbar_height, fill=color, outline='')
             start_pos += timeline_screenshot_width
 
         # Draw current app
         start_pos = width / 2 # start in the middle of the timeline
-        current_app = self.images_df.iloc[current_frame_num]['application']
+        current_app = self.images_df.iloc[self.scroll_frame_num]['application']
         color = self.app_color_map[current_app]
-        self.timeline_canvas.create_rectangle(start_pos, 0, start_pos+timeline_screenshot_width, 50, fill=color, outline="black")
+        self.timeline_canvas.create_rectangle(start_pos, 0, start_pos+timeline_screenshot_width, timeline_scrollbar_height, fill=color, outline="black")
 
-    def display_frame(self, screenshot, frame_num):
-        im_row = self.images_df.iloc[frame_num]
-        print(f"frame_num: {frame_num} frame_id: {im_row['id']}")
+    def update_frame(self):
+        self.update_screenshot()
+        self.update_timeline()
+        self.frame_timestamp.set(f"{self.displayed_image.timestamp.strftime('%A, %Y-%m-%d %H:%M')}")
+
+    def update_screenshot(self):
+        screenshot = resize_screenshot(
+            self.get_screenshot(self.scroll_frame_num),
+            self.video_label.winfo_width(),
+            self.video_label.winfo_height()
+        )
+        im_row = self.images_df.iloc[self.scroll_frame_num]
+        print(f"frame_num: {self.scroll_frame_num} frame_id: {im_row['id']}")
         cv2image = cv2.cvtColor(screenshot.image, cv2.COLOR_BGR2RGB)
         img = Image.fromarray(cv2image)
         imgtk = ImageTk.PhotoImage(image=img)
         self.video_label.imgtk = imgtk
         self.video_label.configure(image=imgtk)
-        self.scroll_frame_num_var.set(f"{screenshot.timestamp.strftime('%A, %Y-%m-%d %H:%M')}")
-        self.update_timeline(frame_num)
         self.displayed_image = screenshot
-        self.displayed_frame_num = frame_num
-    
+
     def bind_scroll_event(self):
         # Detect platform and bind the appropriate event
         os_name = platform.system()
         if os_name == "Linux":
-            self.master.bind("<Button-4>", self.on_scroll_up)
-            self.master.bind("<Button-5>", self.on_scroll_down)
+            self.master.winfo_toplevel().bind("<Button-4>", self.on_scroll_up)
+            self.master.winfo_toplevel().bind("<Button-5>", self.on_scroll_down)
         else:  # Windows and macOS
-            self.master.bind("<MouseWheel>", self.on_mouse_wheel)
+            self.master.winfo_toplevel().bind("<MouseWheel>", self.on_mouse_wheel)
     
+    def scroll_frames(self, delta: int):
+        next_frame_num = self.scroll_frame_num + delta
+
+        if next_frame_num > self.max_frames_index:
+            next_frame_num = self.max_frames_index
+        if next_frame_num < 0:
+            next_frame_num = 0
+        
+        if next_frame_num != self.scroll_frame_num:
+            self.scroll_frame_num = next_frame_num
+            self.update_frame()
+
     def on_mouse_wheel(self, event):
         # Windows and macOS handle scroll direction differently
         if platform.system() == "Windows":
-            self.scroll_frame_num += int(event.delta / 120)
+            self.scroll_frames( int(event.delta / 120) )
         else:  # macOS
-            self.scroll_frame_num -= int(event.delta)
-
-        if self.scroll_frame_num < 0:
-            self.scroll_frame_num = 0
-        
-        if self.scroll_frame_num > self.max_frames_index:
-            self.scroll_frame_num = self.max_frames_index
+            self.scroll_frames( - int(event.delta) )
 
     def on_scroll_up(self, event):
-        # Linux scroll up
-        if self.scroll_frame_num > 0:
-            self.scroll_frame_num -= 1
+        self.scroll_frames(-1)
 
     def on_scroll_down(self, event):
-        # Linux scroll down
-        self.scroll_frame_num += 1
-        if self.scroll_frame_num > self.max_frames_index:
-            self.scroll_frame_num = self.max_frames_index
+        self.scroll_frames(1)
 
     def click_left(self, event):
-        """Move to the next frame on the right."""
-        if self.scroll_frame_num < self.max_frames_index:
-            self.scroll_frame_num += 1
+        self.scroll_frames(1)
 
     def click_right(self, event):
-        """Move to the previous frame on the left."""
-        if self.scroll_frame_num > 0:
-            self.scroll_frame_num -= 1
+        self.scroll_frames(-1)
 
     def start_drag(self, event):
         self.dragging = True
@@ -300,18 +311,25 @@ class TimelineViewer:
         # Import SearchViewer here to avoid circular import issues
         from search_view import SearchViewer
 
-        search_window = tk.Toplevel(self.master)
+        search_window = Toplevel(self.master)
         SearchViewer(search_window)
 
     # When the window is closed, you should also gracefully exit the preload thread
     def on_window_close(self):
+        print('setting exit flag')
         self.exit_flag = True
-        self.master.destroy()
 
 def main():
-    root = tk.Tk()
-    app = TimelineViewer(root, front_camera=None)
-    root.protocol("WM_DELETE_WINDOW", app.on_window_close)  # Handle window close event
+    root = Tk()
+    # Initialize style
+    s = ttk.Style()
+    # Create style used by default for all Frames
+    s.configure('TFrame', background='green')
+    s.configure('Frame1.TFrame', background='red')
+    s.configure('1.TLabel', background='blue')
+
+    root.title("Hindsight Server GUI")
+    app = TimelineViewer(root, database=HindsightDB(), front_camera=None)
     root.mainloop()
 
 if __name__ == "__main__":

--- a/hindsight_server/views/timeline_view.py
+++ b/hindsight_server/views/timeline_view.py
@@ -124,7 +124,6 @@ class TimelineViewer:
         self.update_frame()
     
     def setup_gui(self):
-
         self.top_frame = ttk.Frame(self.master, padding='5 5 5 5', style='1.TFrame')
         self.top_frame.grid(column=0, row=0, sticky='ew')
         self.top_frame.columnconfigure(0, weight=1) # expand top row's column to fill container
@@ -160,12 +159,14 @@ class TimelineViewer:
         self.max_width = self.master.winfo_toplevel().winfo_width()
         self.max_height = self.master.winfo_toplevel().winfo_height()
         print('resized to', (self.max_width, self.max_height))
+        self.master.winfo_toplevel().wm_attributes("-topmost", 1)
         self.master.winfo_toplevel().update() # evaluate geometry manager for cases such as fullscreen and startup
         self.update_frame()
 
     def switch_fullscreen(self, event=None):
         self.full_screen = not self.full_screen
-        self.master.winfo_toplevel().attributes("-fullscreen", 1 if self.full_screen else 0)
+        self.master.winfo_toplevel().wm_attributes("-fullscreen", 1 if self.full_screen else 0)
+        self.master.winfo_toplevel().wm_attributes("-topmost", 1)
 
     def handle_escape(self, event):
         if self.full_screen:

--- a/hindsight_server/views/timeline_view.py
+++ b/hindsight_server/views/timeline_view.py
@@ -155,18 +155,19 @@ class TimelineViewer:
         self.master.winfo_toplevel().bind("<Right>", self.handle_right)
         self.master.winfo_toplevel().bind("<Left>", self.handle_left)
 
+        self.master.winfo_toplevel().update() # evaluate geometry manager for cases such as fullscreen and startup
+
     def handle_resize(self, event):
         self.max_width = self.master.winfo_toplevel().winfo_width()
         self.max_height = self.master.winfo_toplevel().winfo_height()
         print('resized to', (self.max_width, self.max_height))
-        self.master.winfo_toplevel().wm_attributes("-topmost", 1)
-        self.master.winfo_toplevel().update() # evaluate geometry manager for cases such as fullscreen and startup
         self.update_frame()
 
     def switch_fullscreen(self, event=None):
         self.full_screen = not self.full_screen
         self.master.winfo_toplevel().wm_attributes("-fullscreen", 1 if self.full_screen else 0)
-        self.master.winfo_toplevel().wm_attributes("-topmost", 1)
+        self.master.winfo_toplevel().update() # evaluate geometry manager for cases such as fullscreen and startup
+        self.update_frame()
 
     def handle_escape(self, event):
         if self.full_screen:


### PR DESCRIPTION
Rewrite of the timeline, including

1. Encapsulating the timeline view in a ttk frame to make refactoring easier
2. Event-driven updates instead of a timer interval update
3. Using the more modern grid geometry manager
4. Auto-expanding the image to scale to window size, controlled by the ttk geometry manager
5. Enabling fullscreen with the 'F' key
6. Closing the app via the 'Esc' key

The new layout is a grid with a single column filling the window, whose dimensions are pre-determined. The image container is allowed to auto-expand until it fills any space remaining.