### PR TITLE
use exa search in browser feed interface

### DIFF
--- a/hindsight_applications/hindsight_feed/app.py
+++ b/hindsight_applications/hindsight_feed/app.py
@@ -73,12 +73,12 @@ def handle_click():
 @app.route('/submit_query', methods=['POST'])
 def submit_query():
     query = request.form['query'] 
-    print(f"Received query: {query}") 
-    feed_generator.add_content_generator(TopicBrowserSummaryFeeder(name=f"""TopicBrowserSummaryFeeder_{query.replace(" ", "_")}""", 
-                                                description=f"Generates an html page with a summary for all browser history related to {query}",
-                                                topic=query))
+    print(f"Received query: {query}")
+    feed_generator.add_content_generator(ExaTopicFeeder(name=f"exa_autogen_topic_{query}", 
+                                                        description="ExaTopicFeeder generated from a topic provided by the user",
+                                                        topic=query))
     return jsonify(success=True)
-    
+
 if __name__ == '__main__':
     app.run(debug=True)
 

--- a/hindsight_applications/hindsight_feed/chromadb_tools.py
+++ b/hindsight_applications/hindsight_feed/chromadb_tools.py
@@ -44,7 +44,7 @@ def get_content_chromadb_metadata(c):
     return metadata_d_cleaned
 
 def content_to_text(c):
-    if "text" in c.content_generator_specific_data:
+    if c.content_generator_specific_data is not None and "text" in c.content_generator_specific_data:
         return c.title + " " + c.content_generator_specific_data['text']
     else:
         return f"{c.title} {c.summary}"

--- a/hindsight_applications/hindsight_feed/feeders/browser_history_summary/browser_history_summary.py
+++ b/hindsight_applications/hindsight_feed/feeders/browser_history_summary/browser_history_summary.py
@@ -319,7 +319,7 @@ class TopicBrowserSummaryFeeder(BrowserSummaryFeeder):
         return results_history
 
     def get_topic_summary_prompt(self, df):
-        prompt = f"Below are summaries extracted from different webpages that a user looked at yesterday. \n"
+        prompt = f"Below are summaries extracted from different webpages that a user looked at in the past. \n"
         for i, row in df.iterrows():
             prompt += self.get_url_text(row)
         prompt += "Create a list of topics the user was looking at. Answer: \n"


### PR DESCRIPTION
- Fix browser interface by using an exa search instead of a history summary when adding a topic to the feed
- Handle nullable column `content_generator_specific_data`